### PR TITLE
[addition]:  cargo dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ LABEL docker.cargo-make.maintainer="mbround18"
 ARG CARGO_MAKE_VERSION
 ARG ARTIFACT_NAME="cargo-make-v${CARGO_MAKE_VERSION}-x86_64-unknown-linux-musl"
 
-RUN apk --update add openssl wget unzip \
+RUN apk --update add openssl wget unzip cargo \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /tmp/cargo-make \
     && wget -O /tmp/cargo-make/cargo-make.zip \
     https://github.com/sagiegurari/cargo-make/releases/download/${CARGO_MAKE_VERSION}/${ARTIFACT_NAME}.zip \
     && unzip /tmp/cargo-make/cargo-make.zip -d /tmp/cargo-make/ \
     && cp /tmp/cargo-make/${ARTIFACT_NAME}/cargo-make /usr/local/bin \
-    && chmod +x /usr/local/bin/cargo-make  
+    && chmod +x /usr/local/bin/cargo-make
 
 
 


### PR DESCRIPTION
# Description

When used in gitlab-ci, an error occurred because the package manager cargo was missing.
I propose to fix this bug

## Contributions

- I added the new dependecy cargo

## Checklist

- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
